### PR TITLE
Add GitHub Actions workflow to run tests on PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run tests
+        run: yarn test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         node-version: [22.x]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'


### PR DESCRIPTION
## Summary
- PR作成時・master への push 時に `yarn test`（Jest）を自動実行する GitHub Actions ワークフロー (`.github/workflows/test.yml`) を追加
- Node.js 22.x 上で `yarn install --frozen-lockfile` → `yarn test` を実行

## Test plan
- [x] ローカルで `yarn install --frozen-lockfile` が成功することを確認
- [x] ローカルで `yarn test` を実行し、既存のテストスイート（3 suites / 20 tests）が全てパスすることを確認
- [ ] 本 PR 作成後、GitHub Actions 上でワークフローが正常に実行されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaeNigbZiuXM9HCK7imk5q)_